### PR TITLE
when comparing strings to numbers for == and ~=, coerce the numbers to strings

### DIFF
--- a/src/Mages.Core.Tests/YampTests.cs
+++ b/src/Mages.Core.Tests/YampTests.cs
@@ -505,6 +505,30 @@
         {
             Test("abs([1,2,3,4,5,6,7] < 5)", 2.0);
         }
+        
+        [Test]
+        public void StringEqualsNumber()
+        {
+            Test("`1` == 1", true);
+        }
+
+        [Test]
+        public void NumberEqualsString()
+        {
+            Test("1 == `1`", true);
+        }
+
+        [Test]
+        public void StringNotEqualsNumber()
+        {
+            Test("`2` ~= 2", false);
+        }
+
+        [Test]
+        public void NumberNotEqualsString()
+        {
+            Test("2 ~= `2`", false);
+        }
 
         [Test]
         public void Greater()

--- a/src/Mages.Core/Runtime/BinaryOperators.cs
+++ b/src/Mages.Core/Runtime/BinaryOperators.cs
@@ -3,6 +3,7 @@
 using Mages.Core.Runtime.Converters;
 using Mages.Core.Runtime.Functions;
 using System;
+using System.Globalization;
 using System.Numerics;
 
 static class BinaryOperators
@@ -305,6 +306,8 @@ static class BinaryOperators
             If.Is<String, String>(args, EqStrings) ??
             If.IsEither<Double, Complex, Double, Complex>(args, CastNumber, CastNumber, EqCNumbers) ??
             If.IsEither<Double[,], Complex[,], Double[,], Complex[,]>(args, CastMatrix, CastMatrix, EqCMatrices) ??
+            If.Is<Double, String>(args, (a, b) => EqStrings(a.ToString(CultureInfo.InvariantCulture), b)) ??
+            If.Is<String, Double>(args, (a, b) => EqStrings(a, b.ToString(CultureInfo.InvariantCulture))) ??
             Object.ReferenceEquals(args[1], args[0]);
     }
 
@@ -320,6 +323,8 @@ static class BinaryOperators
             If.Is<String, String>(args, NeqStrings) ??
             If.IsEither<Double, Complex, Double, Complex>(args, CastNumber, CastNumber, NeqCNumbers) ??
             If.IsEither<Double[,], Complex[,], Double[,], Complex[,]>(args, CastMatrix, CastMatrix, NeqCMatrices) ??
+            If.Is<Double, String>(args, (a, b) => NeqStrings(a.ToString(CultureInfo.InvariantCulture), b)) ??
+            If.Is<String, Double>(args, (a, b) => NeqStrings(a, b.ToString(CultureInfo.InvariantCulture))) ??
             !Object.ReferenceEquals(args[1], args[0]);
     }
 


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Changed equality comparisons between strings and numbers to coerce the numbers to a string before the comparison.  This is to make the behavior similar to inequality comparisons between strings and numbers.  It is technically a breaking change but I do not know if this is a problem in practice.

```
1 == "1" // true (used to be false)
"1" ~= 1 // false (used to be true)
1 <= "1" // true (existing behavior)
1 >= "1" // true (existing behavior)
```

As you can see, before this change the behavior was a bit weird as there were cases where (a == b) did not equal (a <= b) && (a >= b) as you would expect.  Now the comparison operators all agree.